### PR TITLE
Changed Matrix input to AbstractMatrix.

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -18,7 +18,7 @@ Perceptually Shaded Slope Map by *Pingel, Clarke. 2014* [^pingel2014].
 
 [^pingel2014]: Pingel, Thomas, and Clarke, Keith. 2014. ‘Perceptually Shaded Slope Maps for the Visualization of Digital Surface Models’. Cartographica: The International Journal for Geographic Information and Geovisualization 49 (4): 225–40. <https://doi.org/10/ggnthv>.
 """
-function pssm(A::Array{<:Real,2}; exaggeration=2.3, resolution=1.)
+function pssm(A::AbstractMatrix{<:Real}; exaggeration=2.3, resolution=1.)
     x, y = imgradients(A * exaggeration, ImageFiltering.sobel)
     G = sqrt.(x.^2 .+ y.^2)
 

--- a/src/pmf.jl
+++ b/src/pmf.jl
@@ -20,7 +20,7 @@ Afterwards, one can retrieve the resulting mask for `A` by `A .<= B` or `flags .
 
 [^zhang2003]: Zhang, Keqi, Shu-Ching Chen, Dean Whitman, Mei-Ling Shyu, Jianhua Yan, and Chengcui Zhang. “A Progressive Morphological Filter for Removing Nonground Measurements from Airborne LIDAR Data.” IEEE Transactions on Geoscience and Remote Sensing 41, no. 4 (2003): 872–82. <https://doi.org/10.1109/TGRS.2003.810682>.
 """
-function pmf(A::Array{T,2};
+function pmf(A::AbstractMatrix{T};
     ωₘ::Float64=20.,
     slope::Float64=0.01,
     dhₘ::Float64=2.5,

--- a/src/smf.jl
+++ b/src/smf.jl
@@ -15,7 +15,7 @@ Applies the simple morphological filter by *Pingel et al. (2013)* [^pingel2013] 
 
 [^pingel2013]: Pingel, Thomas J., Keith C. Clarke, and William A. McBride. 2013. ‘An Improved Simple Morphological Filter for the Terrain Classification of Airborne LIDAR Data’. ISPRS Journal of Photogrammetry and Remote Sensing 77 (March): 21–30. <https://doi.org/10.1016/j.isprsjprs.2012.12.002>.
 """
-function smf(A::Array{T,2};
+function smf(A::AbstractMatrix{T};
     ω::Real=17.,
     slope::Real=0.01,
     cellsize::Real=1.0) where T <: Real

--- a/src/spread.jl
+++ b/src/spread.jl
@@ -30,7 +30,7 @@ This is also the method implemented by [PCRaster](https://pcraster.geo.uu.nl/pcr
 
 [^tomlin1983]: Tomlin, Charles Dana. 1983. Digital Cartographic Modeling Techniques in Environmental Planning. Yale University.
 """
-function spread(points::Matrix{<:Real}, initial::Matrix{<:Real}, friction::Matrix{<:Real}; res=1, limit=Inf)
+function spread(points::AbstractMatrix{<:Real}, initial::AbstractMatrix{<:Real}, friction::AbstractMatrix{<:Real}; res=1, limit=Inf)
 
     ofriction = OffsetMatrix(fill(Inf, size(friction) .+ 2), UnitRange.(0, size(points) .+ 1))
     ofriction[begin + 1:end - 1,begin + 1:end - 1] .= friction
@@ -108,7 +108,7 @@ This method should scale much better (linearly) than the [^tomlin1983] method, b
 
 [^eastman1989]: Eastman, J. Ronald. 1989. ‘Pushbroom Algorithms for Calculating Distances in Raster Grids’. In Proceedings, Autocarto, 9:288–97.
 """
-function spread2(points::Matrix{<:Real}, initial::Matrix{<:Real}, friction::Matrix{<:Real}; res=1, limit=Inf, iterations=3)
+function spread2(points::AbstractMatrix{<:Real}, initial::AbstractMatrix{<:Real}, friction::AbstractMatrix{<:Real}; res=1, limit=Inf, iterations=3)
 
     ofriction = OffsetMatrix(fill(Inf, size(friction) .+ 2), UnitRange.(0, size(points) .+ 1))
     ofriction[begin + 1:end - 1,begin + 1:end - 1] .= friction
@@ -146,7 +146,7 @@ end
 spread(points::Matrix{<:Real}, initial::Real, friction::Real; distance=Euclidean(), res=1.0)
 ```
 """
-function spread(points::Matrix{<:Real}, initial::Real, friction::Real; distance=Euclidean(), res=1.0)
+function spread(points::AbstractMatrix{<:Real}, initial::Real, friction::Real; distance=Euclidean(), res=1.0)
     init = fill(initial, size(points))
     return spread(points, init, friction; distance, res)
 end
@@ -163,7 +163,7 @@ as one can just take a direct line to the input points.
 
 The calculated cost is more accurate, as there's no 'zigzag' from cell center to cell center.
 """
-function spread(points::Matrix{<:Real}, initial::Matrix{<:Real}, friction::Real; distance=Euclidean(), res=1.0)
+function spread(points::AbstractMatrix{<:Real}, initial::AbstractMatrix{<:Real}, friction::Real; distance=Euclidean(), res=1.0)
     locations = points .> 0
     I = CartesianIndices(size(points))
 

--- a/src/terrain.jl
+++ b/src/terrain.jl
@@ -22,7 +22,7 @@ roughness(dem::Matrix{<:Real})
 
 Roughness is the largest inter-cell difference of a central pixel and its surrounding cell, as defined in Wilson et al (2007, Marine Geodesy 30:3-35).
 """
-function roughness(dem::Matrix{<:Real})
+function roughness(dem::AbstractMatrix{<:Real})
 
     ex_dem = buffer_array(dem)
     roughness = similar(dem)
@@ -43,7 +43,7 @@ TPI(dem::Matrix{<:Real})
 
 TPI stands for Topographic Position Index, which is defined as the difference between a central pixel and the mean of its surrounding cells (see Wilson et al 2007, Marine Geodesy 30:3-35).
 """
-function TPI(dem::Matrix{<:Real})
+function TPI(dem::AbstractMatrix{<:Real})
 
     ex_dem = buffer_array(dem)
     tpi = similar(dem)
@@ -66,7 +66,7 @@ TRI stands for Terrain Ruggedness Index, which measures the difference between a
 This algorithm uses the square root of the sum of the square of the difference between a central pixel and its surrounding cells.
 This is recommended for terrestrial use cases.
 """
-function TRI(dem::Matrix{<:Real})
+function TRI(dem::AbstractMatrix{<:Real})
 
     ex_dem = buffer_array(dem)
     tri = similar(dem)


### PR DESCRIPTION
Partially fixes #8 

Note that we do use `similar` where we can, sometimes use `copy`. However, there are methods that set output with a filling of `Inf`, or setting a type to `Union{T, Missing}` or even a `view` of an `OffsetMatrix`, probably preventing using anything like `similar`. These methods need rethinking.